### PR TITLE
add comment param to PrivateKey.sign

### DIFF
--- a/lib/minisign/private_key.rb
+++ b/lib/minisign/private_key.rb
@@ -73,10 +73,15 @@ module Minisign
       Ed25519::SigningKey.new(@secret_key.pack('C*'))
     end
 
+    # Sign a file/message
+    #
+    # @param filename [String] The filename to be used in the trusted comment section
+    # @param message [String] The file's contents
+    # @param comment [String] An optional trusted comment to be included in the signature
     # @return [String] the signature in the .minisig format that can be written to a file.
-    def sign(filename, message)
+    def sign(filename, message, comment = nil)
       signature = ed25519_signing_key.sign(blake2b512(message))
-      trusted_comment = "timestamp:#{Time.now.to_i}\tfile:#{filename}\thashed"
+      trusted_comment = comment || "timestamp:#{Time.now.to_i}\tfile:#{filename}\thashed"
       global_signature = ed25519_signing_key.sign("#{signature}#{trusted_comment}")
       [
         'untrusted comment: <arbitrary text>',

--- a/spec/minisign/private_key_spec.rb
+++ b/spec/minisign/private_key_spec.rb
@@ -68,7 +68,7 @@ describe Minisign::PrivateKey do
       @filename = 'encrypted-key.txt'
       @message = SecureRandom.uuid
       File.write("test/generated/#{@filename}", @message)
-      signature = @private_key.sign(@filename, @message)
+      signature = @private_key.sign(@filename, @message, 'this is a trusted comment')
       File.write("test/generated/#{@filename}.minisig", signature)
       @signature = Minisign::Signature.new(signature)
       @public_key = Minisign::PublicKey.new('RWSmKaOrT6m3TGwjwBovgOmlhSbyBUw3hyhnSOYruHXbJa36xHr8rq2M')


### PR DESCRIPTION
An optional param for a custom comment to be signed. If not provided, it will use the following format:

```
timestamp:1706961104	file:example.txt	hashed
```