### PR TITLE
add change password functionality

### DIFF
--- a/bin/minisign
+++ b/bin/minisign
@@ -18,6 +18,9 @@ op = OptionParser.new do |opts|
   opts.on('-C') do |c|
     options[:C] = c
   end
+  opts.on('-W') do |w|
+    options[:W] = w
+  end
   opts.on('-f') do |f|
     options[:f] = f
   end

--- a/bin/minisign
+++ b/bin/minisign
@@ -12,6 +12,12 @@ op = OptionParser.new do |opts|
   opts.on('-G') do |g|
     options[:G] = g
   end
+  opts.on('-R') do |r|
+    options[:R] = r
+  end
+  opts.on('-C') do |c|
+    options[:C] = c
+  end
   opts.on('-f') do |f|
     options[:f] = f
   end
@@ -35,3 +41,4 @@ end
 
 Minisign::CLI.generate(options) if options[:G]
 Minisign::CLI.recreate(options) if options[:R]
+Minisign::CLI.recreate(options) if options[:C]

--- a/lib/minisign/cli.rb
+++ b/lib/minisign/cli.rb
@@ -80,7 +80,7 @@ module Minisign
       print 'Password: '
       private_key = Minisign::PrivateKey.new(File.read(options[:s]), prompt)
       print 'New Password: '
-      new_password = prompt
+      new_password = options[:W] ? nil : prompt
       private_key.change_password! new_password
       File.write(options[:s], private_key)
     end

--- a/lib/minisign/cli.rb
+++ b/lib/minisign/cli.rb
@@ -76,7 +76,7 @@ module Minisign
     end
 
     def self.change_password(options)
-      secret_key = options[:s] || "#{Dir.home}/.minisign/minisign.key"
+      options[:s] || "#{Dir.home}/.minisign/minisign.key"
       print 'Password: '
       private_key = Minisign::PrivateKey.new(File.read(options[:s]), prompt)
       print 'New Password: '

--- a/lib/minisign/cli.rb
+++ b/lib/minisign/cli.rb
@@ -74,5 +74,15 @@ module Minisign
       end
       File.write(public_key, private_key.public_key)
     end
+
+    def self.change_password(options)
+      secret_key = options[:s] || "#{Dir.home}/.minisign/minisign.key"
+      print 'Password: '
+      private_key = Minisign::PrivateKey.new(File.read(options[:s]), prompt)
+      print 'New Password: '
+      new_password = prompt
+      private_key.change_password! new_password
+      File.write(options[:s], private_key)
+    end
   end
 end

--- a/spec/minisign/cli_spec.rb
+++ b/spec/minisign/cli_spec.rb
@@ -55,17 +55,17 @@ describe Minisign::CLI do
 
   describe '.change_password' do
     it 'changes the password for the private key' do
-      FileUtils.cp("test/minisign.key", "test/generated/minisign.key")
+      FileUtils.cp('test/minisign.key', 'test/generated/minisign.key')
       options = {
-        s: "test/generated/minisign.key"
+        s: 'test/generated/minisign.key'
       }
       old_password = 'password'
       new_password = SecureRandom.uuid
       allow(Minisign::CLI).to receive(:prompt).and_return(old_password, new_password)
       Minisign::CLI.change_password(options)
-      expect {
+      expect do
         Minisign::PrivateKey.new(File.read(options[:s]), new_password)
-      }.not_to raise_error
+      end.not_to raise_error
     end
   end
 end

--- a/spec/minisign/cli_spec.rb
+++ b/spec/minisign/cli_spec.rb
@@ -52,4 +52,20 @@ describe Minisign::CLI do
       expect(new_public_key).to eq(existing_public_key)
     end
   end
+
+  describe '.change_password' do
+    it 'changes the password for the private key' do
+      FileUtils.cp("test/minisign.key", "test/generated/minisign.key")
+      options = {
+        s: "test/generated/minisign.key"
+      }
+      old_password = 'password'
+      new_password = SecureRandom.uuid
+      allow(Minisign::CLI).to receive(:prompt).and_return(old_password, new_password)
+      Minisign::CLI.change_password(options)
+      expect {
+        Minisign::PrivateKey.new(File.read(options[:s]), new_password)
+      }.not_to raise_error
+    end
+  end
 end

--- a/spec/minisign/cli_spec.rb
+++ b/spec/minisign/cli_spec.rb
@@ -70,6 +70,8 @@ describe Minisign::CLI do
       end.not_to raise_error
     end
 
+    it 'changes the password for the private key without a password'
+
     it 'removes the password for the private key' do
       allow(Minisign::CLI).to receive(:prompt).and_return(@old_password)
       Minisign::CLI.change_password(@options.merge({ W: true }))

--- a/spec/minisign/cli_spec.rb
+++ b/spec/minisign/cli_spec.rb
@@ -54,17 +54,27 @@ describe Minisign::CLI do
   end
 
   describe '.change_password' do
-    it 'changes the password for the private key' do
+    before do
       FileUtils.cp('test/minisign.key', 'test/generated/minisign.key')
-      options = {
+      @options = {
         s: 'test/generated/minisign.key'
       }
-      old_password = 'password'
+      @old_password = 'password'
+    end
+    it 'changes the password for the private key' do
       new_password = SecureRandom.uuid
-      allow(Minisign::CLI).to receive(:prompt).and_return(old_password, new_password)
-      Minisign::CLI.change_password(options)
+      allow(Minisign::CLI).to receive(:prompt).and_return(@old_password, new_password)
+      Minisign::CLI.change_password(@options)
       expect do
-        Minisign::PrivateKey.new(File.read(options[:s]), new_password)
+        Minisign::PrivateKey.new(File.read(@options[:s]), new_password)
+      end.not_to raise_error
+    end
+
+    it 'removes the password for the private key' do
+      allow(Minisign::CLI).to receive(:prompt).and_return(@old_password)
+      Minisign::CLI.change_password(@options.merge({ W: true }))
+      expect do
+        Minisign::PrivateKey.new(File.read(@options[:s]))
       end.not_to raise_error
     end
   end


### PR DESCRIPTION
## What Changed?

`minisign -C` can change or remove the password for a private key

## Checklist:

- [x] I updated the changelog
- [x] I updated the readme
