### PR TITLE
prevent prompt for unencrypted keys

### DIFF
--- a/lib/minisign/cli.rb
+++ b/lib/minisign/cli.rb
@@ -38,7 +38,6 @@ module Minisign
       puts ''
     end
     # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
 
     def self.prompt
       $stdin.tty? ? $stdin.noecho(&:gets).chomp : $stdin.gets.chomp
@@ -55,7 +54,6 @@ module Minisign
       exit 1
     end
 
-    # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
     def self.generate(options)
       secret_key = options[:s] || "#{Dir.home}/.minisign/minisign.key"
@@ -82,7 +80,6 @@ module Minisign
       end
     end
     # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
 
     def self.recreate(options)
       secret_key = options[:s] || "#{Dir.home}/.minisign/minisign.key"
@@ -112,14 +109,16 @@ module Minisign
       # TODO: multiple files
       options[:x] ||= "#{options[:m]}.minisig"
       options[:s] ||= "#{Dir.home}/.minisign/minisign.key"
-      print 'Password: '
-      # TODO: unencrypted private keys shouldn't prompt
-      private_key = Minisign::PrivateKey.new(File.read(options[:s]), prompt)
+      private_key = begin
+        Minisign::PrivateKey.new(File.read(options[:s]))
+      rescue Minisign::PasswordMissingError
+        print 'Password: '
+        Minisign::PrivateKey.new(File.read(options[:s]), prompt)
+      end
       signature = private_key.sign(options[:m], File.read(options[:m]), options[:t])
       File.write(options[:x], signature)
     end
 
-    # rubocop:disable Metrics/AbcSize
     def self.verify(options)
       options[:x] ||= "#{options[:m]}.minisig"
       options[:p] ||= './minisign.pub'

--- a/spec/minisign/cli_spec.rb
+++ b/spec/minisign/cli_spec.rb
@@ -84,6 +84,23 @@ describe Minisign::CLI do
   end
 
   describe '.sign' do
+    it "doesn't prompt for a password if the key is unencrypted" do
+      expect(Minisign::CLI).not_to receive(:prompt)
+      options = {
+        s: 'test/unencrypted.key',
+        c: 'the untrusted comment',
+        t: 'the trusted comment',
+        m: 'test/generated/.keep'
+      }
+      system(
+        "test/generated/minisign -Sm test/generated/.keep -s #{options[:s]} -t '#{options[:t]}'"
+      )
+      jedisct1_signature = File.read('test/generated/.keep.minisig')
+      File.delete('test/generated/.keep.minisig')
+      Minisign::CLI.sign(options)
+      signature = File.read('test/generated/.keep.minisig')
+      expect(jedisct1_signature).to eq(signature)
+    end
     it 'signs a file' do
       allow(Minisign::CLI).to receive(:prompt).and_return('password')
       options = {


### PR DESCRIPTION
## What Changed?

unencrypted keys no longer prompt for a password

## Checklist:

- [ ] I updated the changelog
- [ ] I updated the readme
