### PR TITLE
add error message for invalid signatures

### DIFF
--- a/lib/minisign/cli.rb
+++ b/lib/minisign/cli.rb
@@ -8,6 +8,7 @@ module Minisign
   module CLI
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/CyclomaticComplexity
     def self.usage
       puts 'Usage:'
       puts 'minisign -G [-f] [-p pubkey_file] [-s seckey_file] [-W]'
@@ -37,7 +38,6 @@ module Minisign
       puts '-v                display version number'
       puts ''
     end
-    # rubocop:enable Metrics/MethodLength
 
     def self.prompt
       $stdin.tty? ? $stdin.noecho(&:gets).chomp : $stdin.gets.chomp
@@ -54,7 +54,6 @@ module Minisign
       exit 1
     end
 
-    # rubocop:disable Metrics/MethodLength
     def self.generate(options)
       secret_key = options[:s] || "#{Dir.home}/.minisign/minisign.key"
       public_key = options[:p] || './minisign.pub'
@@ -79,7 +78,6 @@ module Minisign
         puts "minisign -Vm <file> -P #{pubkey}"
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     def self.recreate(options)
       secret_key = options[:s] || "#{Dir.home}/.minisign/minisign.key"
@@ -126,13 +124,20 @@ module Minisign
       public_key = Minisign::PublicKey.new(options[:P])
       message = File.read(options[:m])
       signature = Minisign::Signature.new(File.read(options[:x]))
-      verification = public_key.verify(signature, message)
+      begin
+        verification = public_key.verify(signature, message)
+      rescue StandardError
+        puts 'Signature verification failed'
+        exit 1
+      end
       return if options[:q]
       return puts message if options[:o]
 
       puts options[:Q] ? signature.trusted_comment : verification
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
   end
 end
 

--- a/spec/minisign/e2e_spec.rb
+++ b/spec/minisign/e2e_spec.rb
@@ -43,5 +43,10 @@ describe 'e2e' do
     command = "minisign -Vm #{path}/.keep -p test/minisign.pub -q"
     expect(`#{command}`).to eq('')
   end
-  it 'shows an error message when the signature is invalid'
+  it 'shows an error message when the signature is invalid' do
+    command = 'minisign -Vm test/example.txt -x test/example.txt.minisig.unverifiable -p test/minisign.pub'
+    expect(`#{command}`).to match(/Signature verification failed/)
+    command = 'minisign -Vm test/example.txt -x test/example.txt.minisig.tampered -p test/minisign.pub'
+    expect(`#{command}`).to match(/Signature verification failed/)
+  end
 end


### PR DESCRIPTION
## What Changed?

invalid signatures now output "Signature verification failed"

## Checklist:

- [ ] I updated the changelog
- [ ] I updated the readme
