### PR TITLE
add password to unencrypted key

### DIFF
--- a/lib/minisign/cli.rb
+++ b/lib/minisign/cli.rb
@@ -95,8 +95,12 @@ module Minisign
 
     def self.change_password(options)
       options[:s] ||= "#{Dir.home}/.minisign/minisign.key"
-      print 'Password: '
-      private_key = Minisign::PrivateKey.new(File.read(options[:s]), prompt)
+      private_key = begin
+        Minisign::PrivateKey.new(File.read(options[:s]))
+      rescue Minisign::PasswordMissingError
+        print 'Password: '
+        Minisign::PrivateKey.new(File.read(options[:s]), prompt)
+      end
       print 'New Password: '
       new_password = options[:W] ? nil : prompt
       private_key.change_password! new_password

--- a/spec/minisign/cli_spec.rb
+++ b/spec/minisign/cli_spec.rb
@@ -72,7 +72,18 @@ describe Minisign::CLI do
       end.not_to raise_error
     end
 
-    it 'changes the password for the private key without a password'
+    it 'changes the password for the private key without a password' do
+      FileUtils.cp('test/unencrypted.key', 'test/generated/unencrypted.key')
+      new_password = SecureRandom.uuid
+      options = {
+        s: 'test/generated/unencrypted.key'
+      }
+      allow(Minisign::CLI).to receive(:prompt).and_return(new_password)
+      Minisign::CLI.change_password(options)
+      expect do
+        Minisign::PrivateKey.new(File.read(options[:s]), new_password)
+      end.not_to raise_error
+    end
 
     it 'removes the password for the private key' do
       allow(Minisign::CLI).to receive(:prompt).and_return(@old_password)


### PR DESCRIPTION
## What Changed?

`change_password` now allows adding a password to an unencrypted key

## Checklist:

- [ ] I updated the changelog
- [ ] I updated the readme
