### PR TITLE
cli password confirmation

### DIFF
--- a/lib/minisign/cli.rb
+++ b/lib/minisign/cli.rb
@@ -67,6 +67,12 @@ module Minisign
       else
         print 'Password: '
         password = prompt
+        print "\nPassword (one more time): "
+        password_confirmation = prompt
+        if password != password_confirmation
+          puts "\nPasswords don't match"
+          exit 1
+        end
         print "\nDeriving a key from the password in order to encrypt the secret key..."
         keypair = Minisign::KeyPair.new(password)
         File.write(secret_key, keypair.private_key)

--- a/spec/minisign/e2e_spec.rb
+++ b/spec/minisign/e2e_spec.rb
@@ -11,8 +11,7 @@ describe 'e2e' do
     keyname = 'ruby-encrypted'
     exe = 'minisign'
     password = SecureRandom.uuid
-    # TODO: prompt a second time for password confirmation
-    command = "echo '#{password}' | #{exe} -G -p #{path}/#{keyname}.pub -s #{path}/#{keyname}.key"
+    command = "echo '#{password}\n#{password}' | #{exe} -G -p #{path}/#{keyname}.pub -s #{path}/#{keyname}.key"
     `#{command}`
     # prompt -f
     expect(`#{command} 2>&1`).to match('Key generation aborted:')
@@ -22,6 +21,8 @@ describe 'e2e' do
     expect(output).to match("The public key was saved as #{path}/#{keyname}.pub - That one can be public.")
     public_key = File.read("#{path}/#{keyname}.pub").split("\n").pop
     expect(output.gsub('+', '')).to match("minisign -Vm <file> -P #{public_key}".gsub('+', ''))
+    command = "echo '#{password}\nnottherightpassword' | #{exe} -G -p #{path}/#{keyname}.pub -s #{path}/#{keyname}.key"
+    expect(`#{command} -f 2>&1`).to match("Passwords don't match")
   end
   it 'signs files' do
     path = 'test/generated'


### PR DESCRIPTION
## What Changed?

Generating a key pair with `minisign -G` now prompts for a password a second time, and exits (1) if the passwords don't match. 

## Checklist:

- [ ] I updated the changelog
- [ ] I updated the readme
