### PR TITLE
add untrusted comments to signatures

### DIFF
--- a/lib/minisign/cli.rb
+++ b/lib/minisign/cli.rb
@@ -123,7 +123,7 @@ module Minisign
         print 'Password: '
         Minisign::PrivateKey.new(File.read(options[:s]), prompt)
       end
-      signature = private_key.sign(options[:m], File.read(options[:m]), options[:t])
+      signature = private_key.sign(options[:m], File.read(options[:m]), options[:t], options[:c])
       File.write(options[:x], signature)
     end
 

--- a/lib/minisign/private_key.rb
+++ b/lib/minisign/private_key.rb
@@ -35,19 +35,19 @@ module Minisign
     #
     # @param filename [String] The filename to be used in the trusted comment section
     # @param message [String] The file's contents
-    # @param comment [String] An optional trusted comment to be included in the signature
+    # @param trusted_comment [String] An optional trusted comment to be included in the signature
+    # @param untrusted_comment [String] An optional untrusted comment
     # @return [Minisign::Signature]
-    def sign(filename, message, comment = nil)
+    def sign(filename, message, trusted_comment = nil, untrusted_comment = nil)
       signature = ed25519_signing_key.sign(blake2b512(message))
-      trusted_comment = comment || "timestamp:#{Time.now.to_i}\tfile:#{filename}\thashed"
+      trusted_comment ||= "timestamp:#{Time.now.to_i}\tfile:#{filename}\thashed"
+      untrusted_comment ||= 'signature from minisign secret key'
       global_signature = ed25519_signing_key.sign("#{signature}#{trusted_comment}")
-      # TODO: allow setting an untrusted comment, too
       Minisign::Signature.new([
-        'untrusted comment: signature from minisign secret key',
+        "untrusted comment: #{untrusted_comment}",
         Base64.strict_encode64("ED#{@key_id.pack('C*')}#{signature}"),
         "trusted comment: #{trusted_comment}",
-        Base64.strict_encode64(global_signature),
-        ''
+        "#{Base64.strict_encode64(global_signature)}\n"
       ].join("\n"))
     end
 

--- a/spec/minisign/cli_spec.rb
+++ b/spec/minisign/cli_spec.rb
@@ -103,9 +103,10 @@ describe Minisign::CLI do
         t: 'the trusted comment',
         m: 'test/generated/.keep'
       }
-      system(
-        "test/generated/minisign -Sm test/generated/.keep -s #{options[:s]} -t '#{options[:t]}'"
-      )
+      # rubocop:disable Layout/LineLength
+      command = "test/generated/minisign -Sm test/generated/.keep -s #{options[:s]} -c '#{options[:c]}' -t '#{options[:t]}'"
+      # rubocop:enable Layout/LineLength
+      system(command)
       jedisct1_signature = File.read('test/generated/.keep.minisig')
       File.delete('test/generated/.keep.minisig')
       Minisign::CLI.sign(options)
@@ -121,7 +122,9 @@ describe Minisign::CLI do
         m: 'test/generated/.keep'
       }
       system(
-        "echo 'password' | test/generated/minisign -Sm test/generated/.keep -s test/minisign.key -t '#{options[:t]}'"
+        # rubocop:disable Layout/LineLength
+        "echo 'password' | test/generated/minisign -Sm #{options[:m]} -s #{options[:s]} -t '#{options[:t]}' -c '#{options[:c]}'"
+        # rubocop:enable Layout/LineLength
       )
       jedisct1_signature = File.read('test/generated/.keep.minisig')
       File.delete('test/generated/.keep.minisig')

--- a/spec/minisign/private_key_spec.rb
+++ b/spec/minisign/private_key_spec.rb
@@ -78,7 +78,11 @@ describe Minisign::PrivateKey do
     it 'signs a file' do
       @filename = 'encrypted-key.txt'
       @message = SecureRandom.uuid
-      signature = @private_key.sign(@filename, @message, 'this is a trusted comment')
+      trusted_comment = 'this is a trusted comment'
+      untrusted_comment = 'this is an untrusted comment'
+      signature = @private_key.sign(@filename, @message, trusted_comment, untrusted_comment)
+      expect(signature.to_s).to match(trusted_comment)
+      expect(signature.to_s).to match(untrusted_comment)
       @public_key = Minisign::PublicKey.new('RWSmKaOrT6m3TGwjwBovgOmlhSbyBUw3hyhnSOYruHXbJa36xHr8rq2M')
       expect(@public_key.verify(signature, @message)).to match('Signature and comment signature verified')
       File.write("test/generated/#{@filename}", @message)


### PR DESCRIPTION
## What Changed?

When creating a signature, it's now possible to add an untrusted comment (implements the `-c` flag)

## Checklist:

- [ ] I updated the changelog
- [ ] I updated the readme
