### PR TITLE
optional libsodium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Make `libsodium` dependency optional for consumers who want to verify signatures _only_
+
 ## [0.2.1] - 2024-02-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ A ruby implemenation of [Minisign](http://jedisct1.github.io/minisign/).
 gem install minisign
 ```
 
+**Note**: This gem has a conditional dependency on [`libsodium`](https://doc.libsodium.org/) for the functionality related to key derivation and signature creation.
+Signature verification _does not_ need `libsodium`.
+
 ### Read a public key
 
 ```rb

--- a/bin/minisign
+++ b/bin/minisign
@@ -31,7 +31,7 @@ rescue OptionParser::InvalidOption
   exit 1
 end
 
-if (options[:G] || options[:R] || options[:G] || options[:S]) && !defined? RbNaCl::Hash
+if (options[:G] || options[:R] || options[:C] || options[:S]) && !defined? RbNaCl::Hash
   warn 'Error: libsodium is not installed!'
   exit 1
 end

--- a/bin/minisign
+++ b/bin/minisign
@@ -31,6 +31,13 @@ rescue OptionParser::InvalidOption
   exit 1
 end
 
+if options[:G] || options[:R] || options[:G] || options[:S]
+  unless defined? RbNaCl::Hash
+    STDERR.puts "Error: libsodium is not installed!"
+    exit 1
+  end
+end
+
 Minisign::CLI.generate(options) if options[:G]
 Minisign::CLI.recreate(options) if options[:R]
 Minisign::CLI.change_password(options) if options[:C]

--- a/bin/minisign
+++ b/bin/minisign
@@ -31,7 +31,7 @@ rescue OptionParser::InvalidOption
   exit 1
 end
 
-if (options[:G] || options[:R] || options[:C] || options[:S]) && !defined? RbNaCl::Hash
+if (options[:G] || options[:R] || options[:C] || options[:S]) && !RbNaCl.const_defined?(:PasswordHash)
   warn 'Error: libsodium is not installed!'
   exit 1
 end

--- a/bin/minisign
+++ b/bin/minisign
@@ -31,11 +31,9 @@ rescue OptionParser::InvalidOption
   exit 1
 end
 
-if options[:G] || options[:R] || options[:G] || options[:S]
-  unless defined? RbNaCl::Hash
-    STDERR.puts "Error: libsodium is not installed!"
-    exit 1
-  end
+if (options[:G] || options[:R] || options[:G] || options[:S]) && !defined? RbNaCl::Hash
+  warn 'Error: libsodium is not installed!'
+  exit 1
 end
 
 Minisign::CLI.generate(options) if options[:G]

--- a/lib/minisign.rb
+++ b/lib/minisign.rb
@@ -2,7 +2,12 @@
 
 require 'ed25519'
 require 'base64'
-require 'rbnacl'
+require 'openssl'
+begin
+    require 'rbnacl'
+rescue LoadError => e
+    # errors handled when invoked (see Minisign::NaCl)
+end
 
 require 'minisign/cli'
 require 'minisign/utils'
@@ -10,4 +15,5 @@ require 'minisign/public_key'
 require 'minisign/signature'
 require 'minisign/private_key'
 require 'minisign/key_pair'
+require 'minisign/nacl'
 require 'minisign/error'

--- a/lib/minisign.rb
+++ b/lib/minisign.rb
@@ -4,9 +4,9 @@ require 'ed25519'
 require 'base64'
 require 'openssl'
 begin
-    require 'rbnacl'
-rescue LoadError => e
-    # errors handled when invoked (see Minisign::NaCl)
+  require 'rbnacl'
+rescue LoadError
+  # errors handled when invoked (see Minisign::NaCl)
 end
 
 require 'minisign/cli'

--- a/lib/minisign/error.rb
+++ b/lib/minisign/error.rb
@@ -9,4 +9,7 @@ module Minisign
 
   class PasswordIncorrectError < StandardError
   end
+
+  class LibSodiumDependencyError < StandardError
+  end
 end

--- a/lib/minisign/nacl.rb
+++ b/lib/minisign/nacl.rb
@@ -1,27 +1,32 @@
+# frozen_string_literal: true
+
 module Minisign
-    module NaCl
-        def self.safely
-            begin
-                yield
-            rescue NameError
-                raise Minisign::LibSodiumDependencyError, 'libsodium is not installed!'
-            end
-        end
-        module Hash
-            module Blake2b
-                def self.digest(*args)
-                    NaCl::safely do
-                        RbNaCl::Hash::Blake2b.digest(*args)
-                    end
-                end
-            end
-        end
-        module PasswordHash
-            def self.scrypt(*args)
-                NaCl::safely do
-                    RbNaCl::PasswordHash.scrypt(*args)
-                end
-            end
-        end
+  # A module that invokes RbNaCl with user-focused actionable error messages.
+  module NaCl
+    def self.safely
+      yield
+    rescue NameError
+      raise Minisign::LibSodiumDependencyError, 'libsodium is not installed!'
     end
+
+    module Hash
+      # see RbNaCl::Hash::Blake2b
+      module Blake2b
+        def self.digest(*args)
+          NaCl.safely do
+            RbNaCl::Hash::Blake2b.digest(*args)
+          end
+        end
+      end
+    end
+
+    # see RbNaCl::PasswordHash
+    module PasswordHash
+      def self.scrypt(*args)
+        NaCl.safely do
+          RbNaCl::PasswordHash.scrypt(*args)
+        end
+      end
+    end
+  end
 end

--- a/lib/minisign/nacl.rb
+++ b/lib/minisign/nacl.rb
@@ -1,0 +1,27 @@
+module Minisign
+    module NaCl
+        def self.safely
+            begin
+                yield
+            rescue NameError
+                raise Minisign::LibSodiumDependencyError, 'libsodium is not installed!'
+            end
+        end
+        module Hash
+            module Blake2b
+                def self.digest(*args)
+                    NaCl::safely do
+                        RbNaCl::Hash::Blake2b.digest(*args)
+                    end
+                end
+            end
+        end
+        module PasswordHash
+            def self.scrypt(*args)
+                NaCl::safely do
+                    RbNaCl::PasswordHash.scrypt(*args)
+                end
+            end
+        end
+    end
+end

--- a/lib/minisign/nacl.rb
+++ b/lib/minisign/nacl.rb
@@ -3,9 +3,9 @@
 module Minisign
   # A module that invokes RbNaCl with user-focused actionable error messages.
   module NaCl
-    def self.safely
-      yield
-    rescue NameError
+    def self.assert_libsodium_dependency_met!
+      return if RbNaCl.const_defined?(:PasswordHash)
+
       raise Minisign::LibSodiumDependencyError, 'libsodium is not installed!'
     end
 
@@ -13,9 +13,8 @@ module Minisign
       # see RbNaCl::Hash::Blake2b
       module Blake2b
         def self.digest(*args)
-          NaCl.safely do
-            RbNaCl::Hash::Blake2b.digest(*args)
-          end
+          NaCl.assert_libsodium_dependency_met!
+          RbNaCl::Hash::Blake2b.digest(*args)
         end
       end
     end
@@ -23,9 +22,8 @@ module Minisign
     # see RbNaCl::PasswordHash
     module PasswordHash
       def self.scrypt(*args)
-        NaCl.safely do
-          RbNaCl::PasswordHash.scrypt(*args)
-        end
+        NaCl.assert_libsodium_dependency_met!
+        RbNaCl::PasswordHash.scrypt(*args)
       end
     end
   end

--- a/lib/minisign/utils.rb
+++ b/lib/minisign/utils.rb
@@ -4,11 +4,11 @@ module Minisign
   # Helpers used in multiple classes
   module Utils
     def blake2b256(message)
-      RbNaCl::Hash::Blake2b.digest(message, { digest_size: 32 })
+      Minisign::NaCl::Hash::Blake2b.digest(message, { digest_size: 32 })
     end
 
     def blake2b512(message)
-      RbNaCl::Hash::Blake2b.digest(message, { digest_size: 64 })
+      OpenSSL::Digest.new('blake2b512').digest(message)
     end
 
     # @return [Array<32 bit unsigned ints>]
@@ -25,7 +25,7 @@ module Minisign
 
     # @return [String] the <kdf_output> used to xor the ed25519 keys
     def derive_key(password, kdf_salt, kdf_opslimit, kdf_memlimit)
-      RbNaCl::PasswordHash.scrypt(
+      Minisign::NaCl::PasswordHash.scrypt(
         password,
         kdf_salt,
         kdf_opslimit,

--- a/spec/minisign/nacl_spec.rb
+++ b/spec/minisign/nacl_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Minisign::NaCl do
-  it 'raises LibSodiumDependencyErro if libsodium not installed' do
+  it 'raises LibSodiumDependencyError if libsodium not installed' do
     hash = RbNaCl.send(:remove_const, :Hash)
     expect do
       Minisign::NaCl::Hash::Blake2b.digest('message', { digest_size: 32 })

--- a/spec/minisign/nacl_spec.rb
+++ b/spec/minisign/nacl_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+describe Minisign::NaCl do
+  it 'raises LibSodiumDependencyErro if libsodium not installed' do
+    hash = RbNaCl.send(:remove_const, :Hash)
+    expect do
+      Minisign::NaCl::Hash::Blake2b.digest('message', { digest_size: 32 })
+    end.to raise_error(Minisign::LibSodiumDependencyError)
+    RbNaCl.const_set(:Hash, hash)
+  end
+end

--- a/spec/minisign/nacl_spec.rb
+++ b/spec/minisign/nacl_spec.rb
@@ -3,9 +3,11 @@
 describe Minisign::NaCl do
   it 'raises LibSodiumDependencyError if libsodium not installed' do
     hash = RbNaCl.send(:remove_const, :Hash)
+    password_hash = RbNaCl.send(:remove_const, :PasswordHash)
     expect do
       Minisign::NaCl::Hash::Blake2b.digest('message', { digest_size: 32 })
     end.to raise_error(Minisign::LibSodiumDependencyError)
     RbNaCl.const_set(:Hash, hash)
+    RbNaCl.const_set(:PasswordHash, password_hash)
   end
 end


### PR DESCRIPTION
## What Changed?

No libsodium? No problem! You can still install this gem and verify signatures without libsodium if you please.

## Checklist:

- [ ] I updated the changelog
- [x] I updated the readme
